### PR TITLE
Isolate harness homes per instance run (claude host HOME, kimi per-instance KIMI_CODE_HOME)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,6 +65,9 @@
 - `run-score` 串联 seed31415 的 `run` 与 `score`；支持 `--parallel` 和
   `--repetitions`，重复流程使用独立输出目录和进程；所有 repetition 的 task
   共用一个有界队列，前一轮尾部释放的槽位须立即由后一轮 task 补位。
+- host-side Claude/Kimi harness home 必须同时按 benchmark execution 与
+  instance run 隔离；execution 结束必须 teardown 清理。目录键须包含原始
+  run key 哈希，Kimi 临时根初始化须支持并发。
 
 ## 任务生命周期
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,6 +65,9 @@
 - `run-score` 串联 seed31415 的 `run` 与 `score`；支持 `--parallel` 和
   `--repetitions`，重复流程使用独立输出目录和进程；所有 repetition 的 task
   共用一个有界队列，前一轮尾部释放的槽位须立即由后一轮 task 补位。
+- host-side Claude/Kimi harness home 必须同时按 benchmark execution 与
+  instance run 隔离；execution 结束必须 teardown 清理。目录键须包含原始
+  run key 哈希，Kimi 临时根初始化须支持并发。
 
 ## 任务生命周期
 

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -443,3 +443,9 @@
   scope; cleanup code is ineffective unless the workflow owner invokes it in a
   `finally` block; predictable truncated names require a content hash.
 - Implementation commit: `bda8c3f`.
+- Review follow-up: Copilot correctly identified that a host
+  `CLAUDE_CONFIG_DIR` containing `~` was not expanded. Use `expanduser()` and
+  cover credential discovery through a user-relative config path; also remove
+  the unused Kimi test import. Targeted tests passed `424`; the full offline
+  suite passed `2264`, with `2 skipped` and `22 deselected`.
+- Review follow-up commit: `1bf84a0`.

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -424,4 +424,4 @@
   container runs stay comparable.
 - Review pending: upstream issue #5, PR #6 (branch
   `task-harness-home-isolation`, implementation commit
-  `12b62b2331f9ce7c1cf3a2337786463e7d41c399`).
+  `12b62b2cbfe5d54d18aae454ac405f13b91d1467`).

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -425,3 +425,21 @@
 - Review pending: upstream issue #5, PR #6 (branch
   `task-harness-home-isolation`, implementation commit
   `12b62b2cbfe5d54d18aae454ac405f13b91d1467`).
+
+## 2026-09: PR #6 execution-level isolation hardening
+
+- Problem: PR #6 keyed Claude homes only by `instance_id + prompt_level`, left
+  them on disk, used collision-prone truncated directory names, and initialized
+  Kimi's temporary root without synchronization. Normal orchestrator runs also
+  never invoked adapter teardown.
+- Resolution: add a unique Claude execution root with teardown cleanup, append
+  a SHA-256 suffix to sanitized run keys, lock Kimi root creation/cleanup, and
+  guarantee orchestrator teardown on success and failure.
+- Verification: added regressions for repeated identical run keys, sanitized-key
+  collisions, concurrent Kimi first use, and exceptional teardown. Targeted
+  adapter/runner tests passed `423`; the full offline suite passed `2263`, with
+  `2 skipped` and `22 deselected`.
+- Prevention: isolation identities must include both execution and instance
+  scope; cleanup code is ineffective unless the workflow owner invokes it in a
+  `finally` block; predictable truncated names require a content hash.
+- Implementation commit: `bda8c3f`.

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -395,3 +395,33 @@
   cache key must include its parent image and installation recipe; real Docker
   acceptance is required when a native CLI schema changes.
 - Implementation commit: `8bc8b8e405d1e97133d26fea7eab425249f5f0c4`.
+
+## 2026-XX: Harness home isolation (claude host HOME, kimi per-instance home)
+
+- Problem: in host-side run modes (`--sandbox none|task|linux_ns`) the Claude
+  Code CLI shared the ambient `HOME` across sequentially executed instances
+  (session transcripts, `~/.claude.json` project history, auto-memory, user
+  hooks/MCP all visible), and `kimi_code_cli` reused one adapter-level
+  `KIMI_CODE_HOME` (with `sessions/` + `logs/`) for every instance, both on
+  the host and via the `--sandbox os` rw mount. Only the OS-sandbox path was
+  inherently safe (one-shot `--rm` container, fresh `HOME=/home/agent`).
+- Resolution: `claude_code_cli` now builds a per-run isolated HOME under
+  `.ai4sci-bench/claude_home/<run_key>/` copying only `.credentials.json` +
+  `settings.json` (same surface as the OS-sandbox auth mounts) and forcing
+  `HOME`/`USERPROFILE`/`CLAUDE_CONFIG_DIR` when `tool_mode != unrestricted`;
+  `kimi_code_cli` now keys auto-generated homes by `run_key` under a temp
+  root removed at teardown (explicit `kimi_home` stays shared by choice);
+  `safe_run_key()` was hoisted into `subprocess_base.py` and codex refactored
+  onto it (behavior-equivalent).
+- Verification: 9 new unit tests (auth mirroring, memory-surface exclusion,
+  per-run keying, `CLAUDE_CONFIG_DIR` override, unrestricted opt-out, kimi
+  per-instance env/mounts, teardown); full suite `uv run pytest -q` →
+  2258 passed, 2 skipped.
+- Prevention: whenever a new harness adapter is added, enumerate every state
+  directory it writes (sessions, history, memory, config) and decide per
+  directory whether it must be per-run, shared-by-explicit-choice, or
+  ephemeral; prefer mirroring the OS-sandbox auth surface so host and
+  container runs stay comparable.
+- Review pending: upstream issue #5, PR #6 (branch
+  `task-harness-home-isolation`, implementation commit
+  `12b62b2331f9ce7c1cf3a2337786463e7d41c399`).

--- a/README.md
+++ b/README.md
@@ -284,8 +284,9 @@ the next model request. Direct endpoints outside the framework proxy remain the
 responsibility of the connected agent.
 
 Harness session state (transcripts, history, auto-memory) never carries over
-between instances: the OS sandbox gives each run a one-shot container with a
-fresh `HOME`, and host-side runs build isolated per-run homes for
+between instances or repeated executions of the same instance: the OS sandbox
+gives each run a one-shot container with a fresh `HOME`, and host-side runs
+build execution-scoped, isolated per-run homes for
 `claude_code_cli` / `codex_cli` and a per-instance `KIMI_CODE_HOME` for
 `kimi_code_cli` (an explicitly configured `kimi_home` stays shared by choice).
 See TEST.md (“Per-run harness home isolation”) for details.

--- a/README.md
+++ b/README.md
@@ -283,6 +283,13 @@ Without this flag, image attachments are replaced with a short notice before
 the next model request. Direct endpoints outside the framework proxy remain the
 responsibility of the connected agent.
 
+Harness session state (transcripts, history, auto-memory) never carries over
+between instances: the OS sandbox gives each run a one-shot container with a
+fresh `HOME`, and host-side runs build isolated per-run homes for
+`claude_code_cli` / `codex_cli` and a per-instance `KIMI_CODE_HOME` for
+`kimi_code_cli` (an explicitly configured `kimi_home` stays shared by choice).
+See TEST.md (“Per-run harness home isolation”) for details.
+
 ## Contribute a task
 
 We welcome project-level scientific tasks from the research community. Authors

--- a/TEST.md
+++ b/TEST.md
@@ -107,6 +107,40 @@ uv run pytest -q tests/test_os_sandbox.py tests/test_os_sandbox_adapters.py \
   tests/test_native_agent_extractors.py tests/test_integration.py
 ```
 
+## Per-run harness home isolation (claude_code / kimi_code / codex)
+
+CLI harnesses keep session transcripts, history, and auto-memory under their
+home directories (e.g. `~/.claude/projects/`, `~/.codex/sessions/`,
+`KIMI_CODE_HOME/sessions/`). To prevent that state from leaking between
+sequentially executed instances:
+
+- **OS sandbox**: each instance runs in a one-shot `--rm` container with a
+  fresh `HOME=/home/agent`, so harness session state is destroyed with the
+  container.
+- **Host-side runs** (`--sandbox none|task|linux_ns`):
+  - `claude_code_cli` builds an isolated per-run `HOME` under
+    `.ai4sci-bench/claude_home/<run_key>/` (tool_mode ≠ unrestricted), copying
+    only `.credentials.json` and `settings.json` and setting
+    `HOME`/`USERPROFILE`/`CLAUDE_CONFIG_DIR`. Sessions, `~/.claude.json`, and
+    ambient user config are excluded.
+  - `codex_cli` builds an isolated per-run `CODEX_HOME` under
+    `.ai4sci-bench/codex_home/<run_key>/` with `--ignore-user-config`.
+  - `kimi_code_cli` generates a per-instance `KIMI_CODE_HOME` subdirectory
+    (keyed by `run_key`) under one adapter-level temp root; an explicitly
+    user-provided `kimi_home` remains shared by choice.
+
+```bash
+uv run pytest -q tests/test_adapters.py tests/test_kimi_adapter.py \
+  tests/test_subprocess_base.py
+```
+
+Coverage includes: isolated HOME construction and auth mirroring, exclusion
+of session/memory surfaces (`.claude/projects/`, `~/.claude.json`), distinct
+homes per instance + prompt level, `CLAUDE_CONFIG_DIR` override semantics,
+unrestricted-mode opt-out, per-instance kimi homes for both host env and
+`--sandbox os` rw mounts, explicit `kimi_home` passthrough, and teardown
+cleanup of the whole home root.
+
 ## CLI Task Draft upload and browser confirmation
 
 Task submission tests cover manual PAT validation and storage, endpoint

--- a/TEST.md
+++ b/TEST.md
@@ -118,8 +118,9 @@ sequentially executed instances:
   fresh `HOME=/home/agent`, so harness session state is destroyed with the
   container.
 - **Host-side runs** (`--sandbox none|task|linux_ns`):
-  - `claude_code_cli` builds an isolated per-run `HOME` under
-    `.ai4sci-bench/claude_home/<run_key>/` (tool_mode ≠ unrestricted), copying
+  - `claude_code_cli` builds an isolated per-run `HOME` under a unique
+    `.ai4sci-bench/claude_home/execution_*/<run_key-hash>/` root
+    (tool_mode ≠ unrestricted), copying
     only `.credentials.json` and `settings.json` and setting
     `HOME`/`USERPROFILE`/`CLAUDE_CONFIG_DIR`. Sessions, `~/.claude.json`, and
     ambient user config are excluded.
@@ -136,10 +137,11 @@ uv run pytest -q tests/test_adapters.py tests/test_kimi_adapter.py \
 
 Coverage includes: isolated HOME construction and auth mirroring, exclusion
 of session/memory surfaces (`.claude/projects/`, `~/.claude.json`), distinct
-homes per instance + prompt level, `CLAUDE_CONFIG_DIR` override semantics,
+homes per instance + prompt level and across repeated executions of the same
+run key, collision-resistant run-key paths, `CLAUDE_CONFIG_DIR` override semantics,
 unrestricted-mode opt-out, per-instance kimi homes for both host env and
-`--sandbox os` rw mounts, explicit `kimi_home` passthrough, and teardown
-cleanup of the whole home root.
+`--sandbox os` rw mounts, concurrent Kimi root initialization, explicit
+`kimi_home` passthrough, and teardown cleanup of the whole home root.
 
 ## CLI Task Draft upload and browser confirmation
 

--- a/ai4sci_bench/adapters/claude_code_cli.py
+++ b/ai4sci_bench/adapters/claude_code_cli.py
@@ -6,6 +6,7 @@ import json
 import logging
 import os
 import shutil
+import tempfile
 import threading
 import time
 from pathlib import Path
@@ -128,6 +129,8 @@ class ClaudeCodeCLIAdapter(SubprocessAgentAdapter):
         self._sandbox_image_identity: str | None = None
         self._proxy: object | None = None
         self._proxy_lock = threading.Lock()
+        self._claude_home_root: Path | None = None
+        self._claude_home_lock = threading.Lock()
 
     @staticmethod
     def _read_env_secret(env_name: str | None) -> str | None:
@@ -280,6 +283,10 @@ class ClaudeCodeCLIAdapter(SubprocessAgentAdapter):
         if self._proxy is not None:
             self._proxy.stop()  # type: ignore[union-attr]
             self._proxy = None
+        with self._claude_home_lock:
+            if self._claude_home_root is not None:
+                shutil.rmtree(self._claude_home_root, ignore_errors=True)
+                self._claude_home_root = None
 
     # ── Env override ───────────────────────────────────────────
 
@@ -313,14 +320,16 @@ class ClaudeCodeCLIAdapter(SubprocessAgentAdapter):
         mounts (``CLAUDE_AUTH_FILENAMES``) are copied in; everything else
         starts empty for this instance + prompt level run.
         """
-        home = (
-            self.repo_root
-            / ".ai4sci-bench"
-            / "claude_home"
-            / safe_run_key(task_instance.run_key)
-        )
-        claude_dir = home / ".claude"
-        claude_dir.mkdir(parents=True, exist_ok=True)
+        with self._claude_home_lock:
+            if self._claude_home_root is None:
+                parent = self.repo_root / ".ai4sci-bench" / "claude_home"
+                parent.mkdir(parents=True, exist_ok=True)
+                self._claude_home_root = Path(tempfile.mkdtemp(
+                    prefix="execution_", dir=parent,
+                ))
+            home = self._claude_home_root / safe_run_key(task_instance.run_key)
+            claude_dir = home / ".claude"
+            claude_dir.mkdir(parents=True, exist_ok=True)
         try:
             os.chmod(home, 0o700)
             os.chmod(claude_dir, 0o700)

--- a/ai4sci_bench/adapters/claude_code_cli.py
+++ b/ai4sci_bench/adapters/claude_code_cli.py
@@ -5,12 +5,15 @@ from __future__ import annotations
 import json
 import logging
 import os
+import shutil
 import threading
 import time
+from pathlib import Path
 
 from ai4sci_bench.adapters.subprocess_base import (
     SubprocessAgentAdapter,
     collect_output_files,
+    safe_run_key,
 )
 from ai4sci_bench.core.types import AgentOutput, CostInfo, RunStatus, TaskInstance, ToolMode
 from ai4sci_bench.runner.os_sandbox import OSSandbox
@@ -23,6 +26,15 @@ CLAUDE_CORE_TOOLS = (
     "EnterWorktree,ExitWorktree"
 )
 CLAUDE_SEARCH_TOOLS = CLAUDE_CORE_TOOLS + ",WebSearch,WebFetch"
+
+# Auth/config files copied into the isolated per-run Claude home for
+# host-side (non-OS-sandbox) execution. Mirrors the read-only auth mounts
+# used by the OS sandbox (runner/os_sandbox.py CLAUDE_AUTH_PATHS) so host
+# and container runs see the same ambient config surface. Everything else
+# under the real HOME — session transcripts, ~/.claude.json project
+# history, todos, auto-memory files, user-scoped MCP servers, skills — is
+# deliberately NOT copied: that is the cross-instance memory surface.
+CLAUDE_AUTH_FILENAMES = (".credentials.json", "settings.json")
 
 
 class ClaudeCodeCLIAdapter(SubprocessAgentAdapter):
@@ -274,11 +286,71 @@ class ClaudeCodeCLIAdapter(SubprocessAgentAdapter):
     def _build_run_env(self, task_instance, task_env) -> dict[str, str] | None:
         base_env = super()._build_run_env(task_instance, task_env)
         api_env = self._build_api_env()
-        if not api_env:
-            return base_env
         env = dict(base_env) if base_env else dict(os.environ)
-        env.update(api_env)
+        if api_env:
+            env.update(api_env)
+        if self.tool_mode != ToolMode.UNRESTRICTED:
+            isolated_home = self._prepare_isolated_claude_home(task_instance)
+            env["HOME"] = str(isolated_home)
+            env["USERPROFILE"] = str(isolated_home)
+            # Overwrite any ambient CLAUDE_CONFIG_DIR so the child cannot
+            # escape the isolated home via a pre-set environment variable.
+            env["CLAUDE_CONFIG_DIR"] = str(isolated_home / ".claude")
         return env
+
+    def _prepare_isolated_claude_home(self, task_instance) -> Path:
+        """Create a minimal per-run Claude home that excludes ambient state.
+
+        Host-side runs (sandbox none/task/linux_ns) must not see the real
+        ``HOME``: Claude Code writes session transcripts, project history,
+        todos and auto-memory under it, and reads user-level config
+        (``~/.claude.json`` MCP servers, hooks, skills) from it. Running
+        instances sequentially with the ambient HOME would let one
+        instance's state — or the user's personal config — influence the
+        next, contaminating benchmark results.
+
+        Only the credential/config files mirrored by the OS sandbox auth
+        mounts (``CLAUDE_AUTH_FILENAMES``) are copied in; everything else
+        starts empty for this instance + prompt level run.
+        """
+        home = (
+            self.repo_root
+            / ".ai4sci-bench"
+            / "claude_home"
+            / safe_run_key(task_instance.run_key)
+        )
+        claude_dir = home / ".claude"
+        claude_dir.mkdir(parents=True, exist_ok=True)
+        try:
+            os.chmod(home, 0o700)
+            os.chmod(claude_dir, 0o700)
+        except OSError:
+            pass
+
+        source_claude_dir = self._host_claude_dir()
+        for filename in CLAUDE_AUTH_FILENAMES:
+            src = source_claude_dir / filename
+            if not src.is_file():
+                continue
+            dst = claude_dir / filename
+            shutil.copy2(src, dst)
+            try:
+                os.chmod(dst, 0o600)
+            except OSError:
+                pass
+
+        logger.info(
+            "claude_code_cli: using isolated per-run HOME at %s", home,
+        )
+        return home
+
+    @staticmethod
+    def _host_claude_dir() -> Path:
+        """Return the real host Claude config dir (honors CLAUDE_CONFIG_DIR)."""
+        config_dir = os.environ.get("CLAUDE_CONFIG_DIR")
+        if config_dir:
+            return Path(config_dir)
+        return Path.home() / ".claude"
 
     # ── Solve ──────────────────────────────────────────────────
 

--- a/ai4sci_bench/adapters/claude_code_cli.py
+++ b/ai4sci_bench/adapters/claude_code_cli.py
@@ -358,7 +358,7 @@ class ClaudeCodeCLIAdapter(SubprocessAgentAdapter):
         """Return the real host Claude config dir (honors CLAUDE_CONFIG_DIR)."""
         config_dir = os.environ.get("CLAUDE_CONFIG_DIR")
         if config_dir:
-            return Path(config_dir)
+            return Path(config_dir).expanduser()
         return Path.home() / ".claude"
 
     # ── Solve ──────────────────────────────────────────────────

--- a/ai4sci_bench/adapters/codex_cli.py
+++ b/ai4sci_bench/adapters/codex_cli.py
@@ -16,6 +16,7 @@ from pathlib import Path
 from ai4sci_bench.adapters.subprocess_base import (
     SubprocessAgentAdapter,
     collect_output_files,
+    safe_run_key,
 )
 from ai4sci_bench.core.types import AgentOutput, CostInfo, RunStatus, TaskInstance, ToolMode
 from ai4sci_bench.runner.os_sandbox import OSSandbox
@@ -506,11 +507,7 @@ class CodexCLIAdapter(SubprocessAgentAdapter):
         CODEX_HOME with config.toml), its config is copied into the
         isolated dir so the provider routing is preserved.
         """
-        safe_run_key = "".join(
-            ch if ch.isalnum() or ch in "._-" else "_"
-            for ch in task_instance.run_key
-        )[:120]
-        home = self.repo_root / ".ai4sci-bench" / "codex_home" / safe_run_key
+        home = self.repo_root / ".ai4sci-bench" / "codex_home" / safe_run_key(task_instance.run_key)
         codex_dir = home / ".codex"
         config_dir = home / ".config"
         codex_dir.mkdir(parents=True, exist_ok=True)

--- a/ai4sci_bench/adapters/kimi_code_cli.py
+++ b/ai4sci_bench/adapters/kimi_code_cli.py
@@ -7,6 +7,7 @@ import logging
 import os
 import shutil
 import tempfile
+import threading
 import time
 import warnings
 from pathlib import Path
@@ -134,6 +135,7 @@ class KimiCodeCLIAdapter(SubprocessAgentAdapter):
             self._uses_native_provider = False
 
         self._temp_kimi_home: str | None = None
+        self._kimi_home_lock = threading.Lock()
         self._os_sandbox: object | None = None
         self._sandbox_image_identity: str | None = None
 
@@ -202,24 +204,25 @@ class KimiCodeCLIAdapter(SubprocessAgentAdapter):
             # User-provided persistent dir: use as-is, don't overwrite their config.
             return self.kimi_home
 
-        root = self._temp_kimi_home
-        if root is None:
-            root = tempfile.mkdtemp(prefix="kimi_home_")
-            os.chmod(root, 0o700)
-            self._temp_kimi_home = root
-            logger.info("kimi_code_cli: generated home root at %s", root)
+        with self._kimi_home_lock:
+            root = self._temp_kimi_home
+            if root is None:
+                root = tempfile.mkdtemp(prefix="kimi_home_")
+                os.chmod(root, 0o700)
+                self._temp_kimi_home = root
+                logger.info("kimi_code_cli: generated home root at %s", root)
 
-        if task_instance is None:
-            home = Path(root)
-        else:
-            home = Path(root) / safe_run_key(task_instance.run_key)
-        home.mkdir(mode=0o700, exist_ok=True)
-        try:
-            os.chmod(home, 0o700)
-        except OSError:
-            pass
+            if task_instance is None:
+                home = Path(root)
+            else:
+                home = Path(root) / safe_run_key(task_instance.run_key)
+            home.mkdir(mode=0o700, exist_ok=True)
+            try:
+                os.chmod(home, 0o700)
+            except OSError:
+                pass
 
-        self._write_kimi_config_if_missing(home)
+            self._write_kimi_config_if_missing(home)
         if task_instance is not None:
             logger.info(
                 "kimi_code_cli: using per-instance KIMI_CODE_HOME at %s", home,
@@ -314,9 +317,10 @@ class KimiCodeCLIAdapter(SubprocessAgentAdapter):
             self._os_sandbox = OSSandbox(self.repo_root)
 
     def teardown(self) -> None:
-        if self._temp_kimi_home is not None:
-            shutil.rmtree(self._temp_kimi_home, ignore_errors=True)
-            self._temp_kimi_home = None
+        with self._kimi_home_lock:
+            if self._temp_kimi_home is not None:
+                shutil.rmtree(self._temp_kimi_home, ignore_errors=True)
+                self._temp_kimi_home = None
 
     # ── Env override ───────────────────────────────────────────
 

--- a/ai4sci_bench/adapters/kimi_code_cli.py
+++ b/ai4sci_bench/adapters/kimi_code_cli.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from ai4sci_bench.adapters.subprocess_base import (
     SubprocessAgentAdapter,
     collect_output_files,
+    safe_run_key,
 )
 from ai4sci_bench.core.types import AgentOutput, CostInfo, RunStatus, TaskInstance, ToolMode
 
@@ -187,28 +188,51 @@ class KimiCodeCLIAdapter(SubprocessAgentAdapter):
 
     # ── Native config file ────────────────────────────────────
 
-    def _ensure_kimi_home(self) -> str:
-        """Return the ``KIMI_CODE_HOME`` dir, generating config.toml if needed."""
+    def _ensure_kimi_home(self, task_instance: TaskInstance | None = None) -> str:
+        """Return the ``KIMI_CODE_HOME`` dir, generating config.toml if needed.
+
+        Auto-generated homes are **per instance run** (keyed by
+        ``task_instance.run_key``) so the session/log state that the Kimi
+        CLI writes under its home cannot leak between sequentially
+        executed instances. A user-provided ``kimi_home`` is shared by
+        explicit choice and is used as-is. Callers without a task instance
+        (legacy/tests) fall back to a single adapter-level shared dir.
+        """
         if self.kimi_home:
             # User-provided persistent dir: use as-is, don't overwrite their config.
             return self.kimi_home
-        if self._temp_kimi_home:
-            return self._temp_kimi_home
 
-        tmpdir = tempfile.mkdtemp(prefix="kimi_home_")
-        os.chmod(tmpdir, 0o700)
+        root = self._temp_kimi_home
+        if root is None:
+            root = tempfile.mkdtemp(prefix="kimi_home_")
+            os.chmod(root, 0o700)
+            self._temp_kimi_home = root
+            logger.info("kimi_code_cli: generated home root at %s", root)
 
-        config_content = self._generate_kimi_config()
-        config_path = os.path.join(tmpdir, "config.toml")
+        if task_instance is None:
+            home = Path(root)
+        else:
+            home = Path(root) / safe_run_key(task_instance.run_key)
+        home.mkdir(mode=0o700, exist_ok=True)
+        try:
+            os.chmod(home, 0o700)
+        except OSError:
+            pass
+
+        self._write_kimi_config_if_missing(home)
+        if task_instance is not None:
+            logger.info(
+                "kimi_code_cli: using per-instance KIMI_CODE_HOME at %s", home,
+            )
+        return str(home)
+
+    def _write_kimi_config_if_missing(self, home: Path) -> None:
+        """Write the generated provider config.toml unless it already exists."""
+        config_path = home / "config.toml"
+        if config_path.exists():
+            return
         with open(config_path, "w", encoding="utf-8") as f:
-            f.write(config_content)
-
-        self._temp_kimi_home = tmpdir
-        logger.info(
-            "kimi_code_cli: generated config at %s (type=%s, base_url=%s)",
-            tmpdir, self._resolved_type, self._resolved_base,
-        )
-        return tmpdir
+            f.write(self._generate_kimi_config())
 
     def _generate_kimi_config(self) -> str:
         cli_type = self._resolved_type or "openai"
@@ -233,18 +257,22 @@ class KimiCodeCLIAdapter(SubprocessAgentAdapter):
 
     _CONTAINER_KIMI_HOME = "/home/agent/.kimi-code"
 
-    def _build_api_env(self) -> dict[str, str]:
+    def _build_api_env(
+        self, task_instance: TaskInstance | None = None,
+    ) -> dict[str, str]:
         """Build env vars for host (non-os) execution."""
         env: dict[str, str] = {}
         if self._uses_native_provider or self.kimi_home:
-            kimi_home = self._ensure_kimi_home()
+            kimi_home = self._ensure_kimi_home(task_instance)
             env["KIMI_CODE_HOME"] = kimi_home
             logger.info("kimi_code_cli: using KIMI_CODE_HOME=%s", kimi_home)
         elif self.api_key:
             env["MOONSHOT_API_KEY"] = self.api_key
         return env
 
-    def _build_os_api_env(self) -> dict[str, str]:
+    def _build_os_api_env(
+        self, task_instance: TaskInstance | None = None,
+    ) -> dict[str, str]:
         """Build env vars for Docker (os sandbox) execution.
 
         KIMI_CODE_HOME must point to the container-internal path, not the
@@ -253,22 +281,27 @@ class KimiCodeCLIAdapter(SubprocessAgentAdapter):
         """
         env: dict[str, str] = {}
         if self._uses_native_provider or self.kimi_home:
-            self._ensure_kimi_home()
+            self._ensure_kimi_home(task_instance)
             env["KIMI_CODE_HOME"] = self._CONTAINER_KIMI_HOME
         elif self.api_key:
             env["MOONSHOT_API_KEY"] = self.api_key
         return env
 
-    def _build_os_extra_mounts(self) -> list[str]:
+    def _build_os_extra_mounts(
+        self, task_instance: TaskInstance | None = None,
+    ) -> list[str]:
         """Build extra Docker volume mounts for os sandbox.
 
         Kimi CLI needs KIMI_CODE_HOME to be writable (it creates sessions/
         and logs/ on startup). We mount the host config dir as rw so that
-        config.toml is visible and subdirectories can be created.
+        config.toml is visible and subdirectories can be created. The
+        host-side dir is per instance run (unless the user supplied an
+        explicit ``kimi_home``), so session state cannot leak between
+        sequentially executed instances.
         """
         mounts: list[str] = []
         if self._uses_native_provider or self.kimi_home:
-            host_kimi_home = self._ensure_kimi_home()
+            host_kimi_home = self._ensure_kimi_home(task_instance)
             mounts += ["-v", f"{host_kimi_home}:{self._CONTAINER_KIMI_HOME}:rw"]
         return mounts
 
@@ -289,7 +322,7 @@ class KimiCodeCLIAdapter(SubprocessAgentAdapter):
 
     def _build_run_env(self, task_instance, task_env) -> dict[str, str] | None:
         base_env = super()._build_run_env(task_instance, task_env)
-        api_env = self._build_api_env()
+        api_env = self._build_api_env(task_instance)
         if not api_env:
             return base_env
         env = dict(base_env) if base_env else dict(os.environ)
@@ -308,8 +341,8 @@ class KimiCodeCLIAdapter(SubprocessAgentAdapter):
         eff_timeout = self._get_effective_timeout(task_instance)
         workspace = task_instance.workspace_dir
         cmd = self._build_os_agent_cmd(workspace)
-        extra_env: dict[str, str] | None = self._build_os_api_env() or None
-        extra_mounts: list[str] = self._build_os_extra_mounts()
+        extra_env: dict[str, str] | None = self._build_os_api_env(task_instance) or None
+        extra_mounts: list[str] = self._build_os_extra_mounts(task_instance)
 
         t0 = time.time()
         assert self._os_sandbox is not None

--- a/ai4sci_bench/adapters/subprocess_base.py
+++ b/ai4sci_bench/adapters/subprocess_base.py
@@ -9,6 +9,7 @@ parsing, working directory, and shell mode.
 from __future__ import annotations
 
 import signal as _signal_module
+import hashlib
 import subprocess
 import time
 from abc import abstractmethod
@@ -57,10 +58,13 @@ def safe_run_key(run_key: str, max_length: int = 120) -> str:
     Used to key per-run isolated homes (e.g. ``.ai4sci-bench/codex_home``)
     so that concurrent or sequential instance runs never share state.
     """
-    return "".join(
+    digest = hashlib.sha256(run_key.encode("utf-8")).hexdigest()[:12]
+    readable = "".join(
         ch if ch.isalnum() or ch in "._-" else "_"
         for ch in run_key
-    )[:max_length]
+    )
+    prefix_length = max(0, max_length - len(digest) - 2)
+    return f"{readable[:prefix_length]}--{digest}"[-max_length:]
 
 
 _SIGNAL_HINTS: dict[int, str] = {

--- a/ai4sci_bench/adapters/subprocess_base.py
+++ b/ai4sci_bench/adapters/subprocess_base.py
@@ -51,6 +51,18 @@ def collect_output_files(
     return files
 
 
+def safe_run_key(run_key: str, max_length: int = 120) -> str:
+    """Sanitize a run key into a safe filesystem directory name.
+
+    Used to key per-run isolated homes (e.g. ``.ai4sci-bench/codex_home``)
+    so that concurrent or sequential instance runs never share state.
+    """
+    return "".join(
+        ch if ch.isalnum() or ch in "._-" else "_"
+        for ch in run_key
+    )[:max_length]
+
+
 _SIGNAL_HINTS: dict[int, str] = {
     9: "likely OOM killed by kernel",
     15: "requested termination",

--- a/ai4sci_bench/runner/orchestrator.py
+++ b/ai4sci_bench/runner/orchestrator.py
@@ -350,31 +350,34 @@ class BenchmarkOrchestrator:
 
     def run(self, task_ids: list[str] | None = None) -> RunReport:
         """Run the full benchmark pipeline."""
-        tasks = self._load_tasks(task_ids or self.config.tasks)
-        instances = self._prepare_instances(tasks)
+        try:
+            tasks = self._load_tasks(task_ids or self.config.tasks)
+            instances = self._prepare_instances(tasks)
 
-        # Save run metadata for reproducibility
-        metadata = self._collect_run_metadata(tasks)
-        save_run_metadata(self.output_dir, metadata)
+            # Save run metadata for reproducibility
+            metadata = self._collect_run_metadata(tasks)
+            save_run_metadata(self.output_dir, metadata)
 
-        # Load completed results for resume support
-        completed_ids = set()
-        if self.config.resume:
-            completed_ids = self._load_completed_ids()
+            # Load completed results for resume support
+            completed_ids = set()
+            if self.config.resume:
+                completed_ids = self._load_completed_ids()
 
-        # Use parallel runner
-        runner = ParallelRunner(max_workers=self.config.parallel)
-        results = runner.run_instances(
-            instances,
-            run_fn=self._run_single_instance,
-            completed_ids=completed_ids,
-        )
+            # Use parallel runner
+            runner = ParallelRunner(max_workers=self.config.parallel)
+            results = runner.run_instances(
+                instances,
+                run_fn=self._run_single_instance,
+                completed_ids=completed_ids,
+            )
 
-        latest_metadata = self._collect_run_metadata(tasks)
-        if latest_metadata != metadata:
-            save_run_metadata(self.output_dir, latest_metadata)
+            latest_metadata = self._collect_run_metadata(tasks)
+            if latest_metadata != metadata:
+                save_run_metadata(self.output_dir, latest_metadata)
 
-        return self._aggregate(results)
+            return self._aggregate(results)
+        finally:
+            self.agent.teardown()
 
     def _run_single_instance(self, instance: TaskInstance) -> EvalResult:
         """Run agent, evaluate, analyze, and save for one instance.

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -16,6 +16,7 @@ from ai4sci_bench.adapters.cli_agent import CLIAgentAdapter
 from ai4sci_bench.adapters.claude_code_cli import ClaudeCodeCLIAdapter
 from ai4sci_bench.adapters.direct_llm import DirectLLMAdapter
 from ai4sci_bench.adapters.codex_cli import CodexCLIAdapter
+from ai4sci_bench.adapters.subprocess_base import safe_run_key
 from ai4sci_bench.runner.task_env import TaskEnvironment
 
 
@@ -32,6 +33,17 @@ class TestAdapterPackageExports:
         assert hasattr(adapters, "ClaudeCodeCLIAdapter")
         assert hasattr(adapters, "CLIAgentAdapter")
         assert hasattr(adapters, "CodexCLIAdapter")
+
+
+def test_safe_run_key_keeps_colliding_prefixes_distinct():
+    left = "a" * 200 + "__b1"
+    right = "a" * 200 + "__b2"
+    assert safe_run_key(left) != safe_run_key(right)
+    assert len(safe_run_key(left)) <= 120
+
+
+def test_safe_run_key_distinguishes_replaced_characters():
+    assert safe_run_key("task/a") != safe_run_key("task?a")
 
 
 class TestAgentAdapterInterface:
@@ -310,6 +322,27 @@ class TestClaudeCodeCLIAdapter:
         assert env_b2["HOME"] != env_b3["HOME"]
         assert Path(env_b2["HOME"]).is_dir()
         assert Path(env_b3["HOME"]).is_dir()
+
+    def test_same_run_key_gets_fresh_home_in_next_execution(
+        self, sample_task_instance, tmp_dir,
+    ):
+        repo_root = tmp_dir / "repo"
+        first = ClaudeCodeCLIAdapter()
+        first.setup({"sandbox": "none", "repo_root": str(repo_root)})
+        home_one = Path(first._build_run_env(sample_task_instance, None)["HOME"])
+        stale = home_one / ".claude" / "memory.md"
+        stale.write_text("previous execution memory", encoding="utf-8")
+        first.teardown()
+        assert not home_one.exists()
+
+        second = ClaudeCodeCLIAdapter()
+        second.setup({"sandbox": "none", "repo_root": str(repo_root)})
+        try:
+            home_two = Path(second._build_run_env(sample_task_instance, None)["HOME"])
+            assert home_two != home_one
+            assert not (home_two / ".claude" / "memory.md").exists()
+        finally:
+            second.teardown()
 
     def test_unrestricted_mode_keeps_ambient_claude_home(self, sample_task_instance, tmp_dir):
         """Unrestricted mode is explicit opt-in to ambient Claude state."""

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -390,6 +390,31 @@ class TestClaudeCodeCLIAdapter:
             Path(env["HOME"]) / ".claude" / ".credentials.json"
         ).read_text() == '{"accessToken": "custom"}'
 
+    def test_isolated_claude_home_expands_host_config_dir(
+        self, sample_task_instance, tmp_dir,
+    ):
+        """A user-relative CLAUDE_CONFIG_DIR still resolves host credentials."""
+        host_home = tmp_dir / "host"
+        host_config = host_home / ".claude-custom"
+        host_config.mkdir(parents=True)
+        (host_config / ".credentials.json").write_text(
+            '{"accessToken": "expanded"}', encoding="utf-8",
+        )
+
+        adapter = ClaudeCodeCLIAdapter()
+        adapter.setup({"sandbox": "none", "repo_root": str(tmp_dir / "repo")})
+
+        with patch.dict(
+            "os.environ",
+            {"HOME": str(host_home), "CLAUDE_CONFIG_DIR": "~/.claude-custom"},
+            clear=True,
+        ):
+            env = adapter._build_run_env(sample_task_instance, task_env=None)
+
+        assert (
+            Path(env["HOME"]) / ".claude" / ".credentials.json"
+        ).read_text() == '{"accessToken": "expanded"}'
+
     def test_init(self):
         adapter = ClaudeCodeCLIAdapter(
             model="claude-sonnet-4-6",

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -3,6 +3,7 @@
 import json
 import os
 import subprocess
+from dataclasses import replace
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -254,6 +255,107 @@ class TestClaudeCodeCLIAdapter:
         adapter.solve(sample_task_instance)
 
         mock_run.assert_called_once()
+
+    def test_restricted_mode_uses_isolated_claude_home(self, sample_task_instance, tmp_dir):
+        """Restricted host-mode Claude runs must not see the ambient HOME.
+
+        Claude Code writes session transcripts, project history, todos and
+        auto-memory under HOME, and reads user-level config (MCP servers,
+        hooks, skills) from ~/.claude.json + ~/.claude/. Sequentially
+        executed instances would otherwise share that memory surface.
+        """
+        host_home = tmp_dir / "host_home"
+        host_claude = host_home / ".claude"
+        host_claude.mkdir(parents=True)
+        (host_claude / ".credentials.json").write_text('{"accessToken": "ok"}')
+        (host_claude / "settings.json").write_text('{"model": "x"}')
+        (host_claude / "projects").mkdir()
+        (host_claude / "projects" / "session.jsonl").write_text("{}")
+        (host_home / ".claude.json").write_text('{"mcpServers": {}}')
+
+        adapter = ClaudeCodeCLIAdapter()
+        adapter.setup({"sandbox": "none", "repo_root": str(tmp_dir / "repo")})
+
+        with patch.dict(
+            "os.environ",
+            {"HOME": str(host_home), "USERPROFILE": str(host_home)},
+            clear=True,
+        ):
+            env = adapter._build_run_env(sample_task_instance, task_env=None)
+
+        isolated_home = Path(env["HOME"])
+        isolated_claude = isolated_home / ".claude"
+        assert isolated_home.is_relative_to(
+            tmp_dir / "repo" / ".ai4sci-bench" / "claude_home"
+        )
+        assert env["USERPROFILE"] == str(isolated_home)
+        assert env["CLAUDE_CONFIG_DIR"] == str(isolated_claude)
+        # Auth/config files are mirrored (same surface as OS sandbox mounts).
+        assert (isolated_claude / ".credentials.json").read_text() == '{"accessToken": "ok"}'
+        assert (isolated_claude / "settings.json").read_text() == '{"model": "x"}'
+        # Memory surfaces are NOT copied.
+        assert not (isolated_claude / "projects").exists()
+        assert not (isolated_home / ".claude.json").exists()
+
+    def test_isolated_claude_home_differs_per_run(self, sample_task_instance, tmp_dir):
+        """Each instance + prompt level run gets its own isolated HOME."""
+        adapter = ClaudeCodeCLIAdapter()
+        adapter.setup({"sandbox": "none", "repo_root": str(tmp_dir / "repo")})
+        other_level = replace(sample_task_instance, prompt_level=PromptLevel.B3)
+
+        with patch.dict("os.environ", {"HOME": "/host"}, clear=True):
+            env_b2 = adapter._build_run_env(sample_task_instance, task_env=None)
+            env_b3 = adapter._build_run_env(other_level, task_env=None)
+
+        assert env_b2["HOME"] != env_b3["HOME"]
+        assert Path(env_b2["HOME"]).is_dir()
+        assert Path(env_b3["HOME"]).is_dir()
+
+    def test_unrestricted_mode_keeps_ambient_claude_home(self, sample_task_instance, tmp_dir):
+        """Unrestricted mode is explicit opt-in to ambient Claude state."""
+        host_home = tmp_dir / "host_home"
+        adapter = ClaudeCodeCLIAdapter(tool_mode="unrestricted")
+        adapter.setup({"sandbox": "none", "repo_root": str(tmp_dir / "repo")})
+
+        with patch.dict("os.environ", {"HOME": str(host_home)}, clear=True):
+            env = adapter._build_run_env(sample_task_instance, task_env=None)
+
+        assert env["HOME"] == str(host_home)
+        assert "CLAUDE_CONFIG_DIR" not in env
+
+    def test_isolated_claude_home_overrides_ambient_config_dir(self, sample_task_instance, tmp_dir):
+        """A pre-set CLAUDE_CONFIG_DIR must not defeat HOME isolation."""
+        adapter = ClaudeCodeCLIAdapter()
+        adapter.setup({"sandbox": "none", "repo_root": str(tmp_dir / "repo")})
+
+        with patch.dict(
+            "os.environ",
+            {"HOME": "/host", "CLAUDE_CONFIG_DIR": "/ambient/claude"},
+            clear=True,
+        ):
+            env = adapter._build_run_env(sample_task_instance, task_env=None)
+
+        assert env["CLAUDE_CONFIG_DIR"] == str(Path(env["HOME"]) / ".claude")
+
+    def test_isolated_claude_home_honors_host_config_dir(self, sample_task_instance, tmp_dir):
+        """Credentials are sourced from CLAUDE_CONFIG_DIR when set on the host."""
+        host_config = tmp_dir / "custom_claude"
+        host_config.mkdir()
+        (host_config / ".credentials.json").write_text('{"accessToken": "custom"}')
+
+        adapter = ClaudeCodeCLIAdapter()
+        adapter.setup({"sandbox": "none", "repo_root": str(tmp_dir / "repo")})
+
+        with patch.dict(
+            "os.environ",
+            {"HOME": str(tmp_dir / "host"), "CLAUDE_CONFIG_DIR": str(host_config)},
+            clear=True,
+        ):
+            env = adapter._build_run_env(sample_task_instance, task_env=None)
+
+        assert (
+            Path(env["HOME"]) / ".claude" / ".credentials.json"
+        ).read_text() == '{"accessToken": "custom"}'
 
     def test_init(self):
         adapter = ClaudeCodeCLIAdapter(

--- a/tests/test_kimi_adapter.py
+++ b/tests/test_kimi_adapter.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import warnings
+from pathlib import Path
 
 import pytest
 
@@ -277,6 +278,97 @@ def test_teardown_removes_temp_kimi_home():
     assert tmp is not None and os.path.isdir(tmp)
     adapter.teardown()
     assert not os.path.exists(tmp)
+    assert adapter._temp_kimi_home is None
+
+
+class _RunKeyStub:
+    """Minimal task-instance stand-in exposing only run_key."""
+
+    def __init__(self, run_key: str):
+        self.run_key = run_key
+
+
+def test_native_mode_homes_differ_per_instance(tmp_path):
+    """Sequentially executed instances must not share a KIMI_CODE_HOME.
+
+    Kimi CLI writes sessions/ and logs/ under its home; a shared dir would
+    leak state from one instance into the next.
+    """
+    import os
+    adapter = KimiCodeCLIAdapter(
+        api_key="sk-test",
+        api_base="https://api.kimi.com/coding/v1",
+    )
+    try:
+        inst_a = _RunKeyStub("task__inst1__seed0__b2")
+        inst_b = _RunKeyStub("task__inst2__seed1__b2")
+
+        env_a = adapter._build_api_env(inst_a)
+        env_b = adapter._build_api_env(inst_b)
+
+        home_a = Path(env_a["KIMI_CODE_HOME"])
+        home_b = Path(env_b["KIMI_CODE_HOME"])
+        assert home_a != home_b
+        assert home_a.is_relative_to(adapter._temp_kimi_home)
+        assert home_b.is_relative_to(adapter._temp_kimi_home)
+        assert home_a.is_dir() and home_b.is_dir()
+        # Both homes carry the generated provider config.
+        for home in (home_a, home_b):
+            content = (home / "config.toml").read_text()
+            assert 'base_url = "https://api.kimi.com/coding/v1"' in content
+        # Same instance resolves to the same home (retries are deterministic).
+        assert adapter._build_api_env(inst_a)["KIMI_CODE_HOME"] == str(home_a)
+    finally:
+        adapter.teardown()
+
+
+def test_os_sandbox_mounts_are_per_instance():
+    """OS-sandbox rw mounts must map a per-instance host dir into the container."""
+    adapter = KimiCodeCLIAdapter(
+        api_key="sk-test",
+        api_base="https://api.kimi.com/coding/v1",
+    )
+    try:
+        mounts_a = adapter._build_os_extra_mounts(_RunKeyStub("task__inst1__seed0__b2"))
+        mounts_b = adapter._build_os_extra_mounts(_RunKeyStub("task__inst2__seed1__b2"))
+
+        assert len(mounts_a) == 2 and len(mounts_b) == 2
+        assert mounts_a[1].split(":")[0] != mounts_b[1].split(":")[0]
+        assert mounts_a[1].split(":")[1] == adapter._CONTAINER_KIMI_HOME
+        assert mounts_a[1].endswith(":rw")
+    finally:
+        adapter.teardown()
+
+
+def test_user_kimi_home_is_shared_across_instances(tmp_path):
+    """An explicit kimi_home is shared by choice and never isolated."""
+    user_home = tmp_path / "my-kimi"
+    user_home.mkdir()
+    (user_home / "config.toml").write_text("# my hand-tuned config\n")
+
+    adapter = KimiCodeCLIAdapter(kimi_home=str(user_home))
+    env_a = adapter._build_api_env(_RunKeyStub("task__inst1__seed0__b2"))
+    env_b = adapter._build_api_env(_RunKeyStub("task__inst2__seed1__b2"))
+
+    assert env_a["KIMI_CODE_HOME"] == str(user_home)
+    assert env_b["KIMI_CODE_HOME"] == str(user_home)
+    assert (user_home / "config.toml").read_text() == "# my hand-tuned config\n"
+
+
+def test_teardown_removes_all_instance_homes():
+    import os
+    adapter = KimiCodeCLIAdapter(
+        api_key="sk-test",
+        api_base="https://api.kimi.com/coding/v1",
+    )
+    adapter._build_api_env(_RunKeyStub("task__inst1__seed0__b2"))
+    adapter._build_api_env(_RunKeyStub("task__inst2__seed1__b2"))
+    root = adapter._temp_kimi_home
+    assert root is not None and os.path.isdir(root)
+
+    adapter.teardown()
+
+    assert not os.path.exists(root)
     assert adapter._temp_kimi_home is None
 
 

--- a/tests/test_kimi_adapter.py
+++ b/tests/test_kimi_adapter.py
@@ -3,6 +3,9 @@
 from __future__ import annotations
 
 import warnings
+import concurrent.futures
+import tempfile
+import time
 from pathlib import Path
 
 import pytest
@@ -370,6 +373,33 @@ def test_teardown_removes_all_instance_homes():
 
     assert not os.path.exists(root)
     assert adapter._temp_kimi_home is None
+
+
+def test_concurrent_first_use_creates_one_managed_root(monkeypatch):
+    created = []
+    real_mkdtemp = tempfile.mkdtemp
+
+    def slow_mkdtemp(*args, **kwargs):
+        time.sleep(0.02)
+        path = real_mkdtemp(*args, **kwargs)
+        created.append(path)
+        return path
+
+    monkeypatch.setattr(
+        "ai4sci_bench.adapters.kimi_code_cli.tempfile.mkdtemp", slow_mkdtemp,
+    )
+    adapter = KimiCodeCLIAdapter(
+        api_key="sk-test", api_base="https://api.kimi.com/coding/v1",
+    )
+    try:
+        instances = [_RunKeyStub(f"task__instance_{i}__b1") for i in range(12)]
+        with concurrent.futures.ThreadPoolExecutor(max_workers=12) as pool:
+            homes = list(pool.map(adapter._build_api_env, instances))
+        assert len(created) == 1
+        root = Path(adapter._temp_kimi_home)
+        assert all(Path(env["KIMI_CODE_HOME"]).is_relative_to(root) for env in homes)
+    finally:
+        adapter.teardown()
 
 
 # ── build_command uses "bench-model" alias only when native ────

--- a/tests/test_kimi_adapter.py
+++ b/tests/test_kimi_adapter.py
@@ -297,7 +297,6 @@ def test_native_mode_homes_differ_per_instance(tmp_path):
     Kimi CLI writes sessions/ and logs/ under its home; a shared dir would
     leak state from one instance into the next.
     """
-    import os
     adapter = KimiCodeCLIAdapter(
         api_key="sk-test",
         api_base="https://api.kimi.com/coding/v1",

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -89,6 +89,18 @@ class FailingAgent(AgentAdapter):
 
 
 class TestBenchmarkOrchestrator:
+    def test_run_tears_down_agent_when_pipeline_fails(self, tmp_path, monkeypatch):
+        agent = MagicMock(spec=AgentAdapter)
+        orchestrator = BenchmarkOrchestrator(RunConfig(
+            agent=agent, tasks_dir=str(tmp_path), output_dir=str(tmp_path / "out"),
+        ))
+        monkeypatch.setattr(
+            orchestrator, "_load_tasks", MagicMock(side_effect=RuntimeError("boom")),
+        )
+        with pytest.raises(RuntimeError, match="boom"):
+            orchestrator.run()
+        agent.teardown.assert_called_once_with()
+
     def test_prepare_instances_with_fixed_params(self, sample_task_dir, tmp_dir):
         """Fixed params should generate exactly one instance per prompt level."""
         metadata = yaml.safe_load((sample_task_dir / "task.yaml").read_text())


### PR DESCRIPTION
Closes #5

## Summary

CLI harnesses keep session transcripts, history, and auto-memory under their home directories. Sequentially executed benchmark instances previously shared that state in host-side run modes (`--sandbox none|task|linux_ns`). The OS-sandbox path was already safe (one-shot `--rm` container, fresh `HOME=/home/agent`). This PR closes the two remaining leak surfaces:

1. **claude_code_cli — per-run isolated HOME** (mirrors the existing codex `_prepare_isolated_codex_home` pattern):
   - `tool_mode != unrestricted`: builds `.ai4sci-bench/claude_home/<run_key>/`, copies only `.credentials.json` + `settings.json` (exactly the files the OS-sandbox auth mounts expose), and sets `HOME` / `USERPROFILE` / `CLAUDE_CONFIG_DIR` (overriding any ambient `CLAUDE_CONFIG_DIR`).
   - Deliberately NOT copied: sessions, `~/.claude.json`, projects/, todos, memory files, user-scoped MCP servers, skills.
   - `tool_mode == unrestricted` stays an explicit opt-in to ambient config.
2. **kimi_code_cli — per-instance KIMI_CODE_HOME**:
   - Auto-generated homes become per-instance subdirectories keyed by `run_key` under one adapter-level temp root (used by both host env and the `--sandbox os` rw mount); teardown removes the whole root.
   - An explicitly user-provided `kimi_home` remains shared by choice (it is the auth/config carrier).
3. **`safe_run_key()`** moved to `subprocess_base.py`; `codex_cli` refactored to use it (behavior-equivalent, covered by existing tests).

## Notes for reviewers

- `settings.json` is copied on purpose for parity with the OS sandbox, which mounts the same file read-only today — so host-mode runs see the same ambient config surface as `--sandbox os`. Hooks in user settings remain an accepted exposure in both paths; happy to flip to credentials-only if reviewers prefer a stricter surface.
- Retries of the same instance reuse the same per-run home (same `run_key`), consistent with codex behavior; harnesses are run one-shot and never resume sessions.
- Claude host-mode previously returned `None` env when no task env / api env existed; it now always returns an explicit env dict (equivalent semantics plus isolation).

## Test evidence

- 9 new test cases: `tests/test_adapters.py` (claude isolation: auth mirroring, memory-surface exclusion, per-run keying, unrestricted opt-out, `CLAUDE_CONFIG_DIR` override, host `CLAUDE_CONFIG_DIR` source) and `tests/test_kimi_adapter.py` (per-instance env + os mounts, explicit `kimi_home` passthrough, teardown cleanup).
- Full suite: `uv run pytest -q` → **2258 passed, 2 skipped, 22 deselected** (no regressions).
- Docs: TEST.md gains a “Per-run harness home isolation” section; README notes the guarantee.