### PR TITLE
fix: add CMOS OPAMP Dockerfile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,16 +60,39 @@ jobs:
           path: dist/
           if-no-files-found: error
 
+  docker-integration:
+    name: Docker runtime integration
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v7.0.1
+      - uses: astral-sh/setup-uv@v9.0.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: uv.lock
+      - name: Install Python
+        run: uv python install 3.11
+      - name: Sync the locked development environment
+        run: uv sync --locked --python 3.11
+      - name: Verify Docker is available
+        run: docker info
+      - name: Run custom task image integration tests
+        run: >-
+          uv run --frozen pytest -q -m integration
+          tests/test_os_sandbox_p1p2p3.py::TestTaskDockerfileAgentOverlayIntegration
+
   required:
     name: CI required
     if: ${{ always() }}
-    needs: [tests, build]
+    needs: [tests, build, docker-integration]
     runs-on: ubuntu-latest
     steps:
       - name: Verify required jobs
         env:
           TESTS_RESULT: ${{ needs.tests.result }}
           BUILD_RESULT: ${{ needs.build.result }}
+          DOCKER_INTEGRATION_RESULT: ${{ needs.docker-integration.result }}
         run: |
           test "$TESTS_RESULT" = success
           test "$BUILD_RESULT" = success
+          test "$DOCKER_INTEGRATION_RESULT" = success

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,12 +10,16 @@
 ## ASI-Bench 公开边界
 
 - 正式任务目录 `tasks/<domain>/<name>/` 公开 `task_meta.yaml`、只含
-  评分/输出契约的 `task_eval.yaml` 以及可选 `custom_scorer.py`；不跟踪
+  评分/输出契约的 `task_eval.yaml`、可选 `custom_scorer.py`，以及
+  `config/public_task_runtimes.json` 精确列出的 task runtime 文件；不跟踪
   benchmark prompts、`generation` 配置、GT 生成器、reference specs、参考
   答案或私有求解器资产。
 - `config/public_scorers.json` 是正式任务公开评分器的精确 allowlist 和来源
   revision；正式任务严禁出现 `generate_gt.py`、`precompute_gt.py`、
   `reference_specs.md`、reference/ground-truth 目录或 `private_assets` / `reference_solver`。
+- `config/public_task_runtimes.json` 是正式任务公开 runtime 文件的精确 task-level
+  allowlist；其中的文件必须由 `task_meta.yaml` 显式声明并仅提供可复现执行环境，
+  不得包含 prompt、reference、GT 或私有求解逻辑。
 - 公开 scorer 只消费预生成的 instance/reference bundle，不得接受 seed
   或重建 GT。`config/public_scorers.json` 可精确列出通用 helper 和
   evaluator-only `*_eval_runtime.py`；这些 runtime 不得包含 generator、

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,8 +60,10 @@
   `prediction_dir` 绑定到其 persisted outputs，分别报告 attempt 与 evaluation 状态。
 - 原生 pi/opencode adapter 必须先解析 `api_key_env`/api_base_env 再做校验；provenance 只保留 endpoint 和环境变量名，禁止持久化 API key。CLI 版本必须用 `--version`/help 实测确认。
 - pi/opencode 的 OS 镜像固定 pi `0.84.3`、opencode `1.17.15` 和 Node 22；
-  prompt 通过 `docker run -i` 的 stdin 传入。agent image cache identity 必须绑定
-  base schema 与精确安装命令，produce-only result 也必须持久化原生 token cost。
+  prompt 通过 `docker run -i` 的 stdin 传入。`runtime.dockerfile` 只构建可复用的
+  task 基础镜像，框架必须按当前 `agent_type` 单独叠加且只安装所选 CLI；无 agent
+  时直接使用 task 基础镜像。agent image cache identity 必须绑定 task/base image、
+  agent 类型与精确安装命令，produce-only result 也必须持久化原生 token cost。
 - 持久化元数据的路径脱敏必须保留完整 HTTP(S) API endpoint，只替换 URL
   之外的宿主机绝对路径；agent 执行失败必须报告为 `attempt_status:
   execution_failed`，不得与 scorer 完成或低分混淆。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,12 +10,16 @@
 ## ASI-Bench 公开边界
 
 - 正式任务目录 `tasks/<domain>/<name>/` 公开 `task_meta.yaml`、只含
-  评分/输出契约的 `task_eval.yaml` 以及可选 `custom_scorer.py`；不跟踪
+  评分/输出契约的 `task_eval.yaml`、可选 `custom_scorer.py`，以及
+  `config/public_task_runtimes.json` 精确列出的 task runtime 文件；不跟踪
   benchmark prompts、`generation` 配置、GT 生成器、reference specs、参考
   答案或私有求解器资产。
 - `config/public_scorers.json` 是正式任务公开评分器的精确 allowlist 和来源
   revision；正式任务严禁出现 `generate_gt.py`、`precompute_gt.py`、
   `reference_specs.md`、reference/ground-truth 目录或 `private_assets` / `reference_solver`。
+- `config/public_task_runtimes.json` 是正式任务公开 runtime 文件的精确 task-level
+  allowlist；其中的文件必须由 `task_meta.yaml` 显式声明并仅提供可复现执行环境，
+  不得包含 prompt、reference、GT 或私有求解逻辑。
 - 公开 scorer 只消费预生成的 instance/reference bundle，不得接受 seed
   或重建 GT。`config/public_scorers.json` 可精确列出通用 helper 和
   evaluator-only `*_eval_runtime.py`；这些 runtime 不得包含 generator、

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,8 +60,10 @@
   `prediction_dir` 绑定到其 persisted outputs，分别报告 attempt 与 evaluation 状态。
 - 原生 pi/opencode adapter 必须先解析 `api_key_env`/api_base_env 再做校验；provenance 只保留 endpoint 和环境变量名，禁止持久化 API key。CLI 版本必须用 `--version`/help 实测确认。
 - pi/opencode 的 OS 镜像固定 pi `0.84.3`、opencode `1.17.15` 和 Node 22；
-  prompt 通过 `docker run -i` 的 stdin 传入。agent image cache identity 必须绑定
-  base schema 与精确安装命令，produce-only result 也必须持久化原生 token cost。
+  prompt 通过 `docker run -i` 的 stdin 传入。`runtime.dockerfile` 只构建可复用的
+  task 基础镜像，框架必须按当前 `agent_type` 单独叠加且只安装所选 CLI；无 agent
+  时直接使用 task 基础镜像。agent image cache identity 必须绑定 task/base image、
+  agent 类型与精确安装命令，produce-only result 也必须持久化原生 token cost。
 - 持久化元数据的路径脱敏必须保留完整 HTTP(S) API endpoint，只替换 URL
   之外的宿主机绝对路径；agent 执行失败必须报告为 `attempt_status:
   execution_failed`，不得与 scorer 完成或低分混淆。

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -633,3 +633,22 @@
 - Verification: public-policy coverage rejects Gemini Judge configs and checks
   all GPT Judge configs; targeted Judge and policy tests pass.
 - Implementation commit: `8e474b7`.
+
+## 2026-09: Add selected-agent overlays for custom task images
+
+- Problem: `runtime.dockerfile` returned the task image directly, so formal task
+  Dockerfiles had to bundle agent CLIs and could not provide agent-specific
+  cache identities; the CMOS image also lacked regression coverage for Linux
+  host UID remapping.
+- Resolution: treat a custom Dockerfile as a reusable task base, layer only the
+  selected agent CLI on top, include the task-base identity and exact agent
+  install command in the overlay cache key, and keep no-agent runs on the task
+  base. Remove bundled Claude/Codex CLIs from the CMOS base image.
+- Verification: `218 passed, 2 skipped, 1 deselected` across the OS sandbox,
+  pi, and opencode suites; the Docker integration test built the CMOS base and
+  pi overlay, then passed ngspice, Python-package, pi CLI, agent-isolation, and
+  UID/GID `12345:12345` HOME-write probes.
+- Prevention: custom task Dockerfiles must provide task dependencies only;
+  agent installation belongs to framework-managed, agent-keyed overlays with
+  both mock coverage and an opt-in Docker runtime probe.
+- Implementation commit: `361f093`.

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -652,3 +652,20 @@
   agent installation belongs to framework-managed, agent-keyed overlays with
   both mock coverage and an opt-in Docker runtime probe.
 - Implementation commit: `361f093`.
+
+## 2026-09: Close custom task image PR policy and CI gaps
+
+- Problem: the CMOS `Dockerfile.os` was rejected by the fail-closed public-task
+  policy, while its real UID-remapping and agent CLI probes were excluded from
+  the required CI workflow; cache tests also did not directly prove that a
+  Dockerfile content change invalidates the selected-agent overlay.
+- Resolution: add an exact task-level public runtime allowlist, require it to
+  match every formal `runtime.dockerfile` declaration, add the focused Docker
+  integration suite to `CI required`, and cover both Dockerfile-content cache
+  invalidation and the original Claude Code executable smoke path.
+- Verification: public policy, task image, and CI workflow tests pass; the
+  Docker integration suite validates pi and Claude Code overlays separately.
+- Prevention: formal task runtime files must be explicitly allowlisted, and any
+  custom-image agent regression must have both offline cache coverage and a
+  required Linux Docker smoke test.
+- Implementation commit: `41e5615`.

--- a/README.md
+++ b/README.md
@@ -365,6 +365,12 @@ build execution-scoped, isolated per-run homes for
 `kimi_code_cli` (an explicitly configured `kimi_home` stays shared by choice).
 See TEST.md (“Per-run harness home isolation”) for details.
 
+For `runtime.dockerfile`, the declared Dockerfile builds the reusable task base
+image. When an OS-sandbox agent is selected, ASI-Bench layers only that agent's
+CLI onto the task base; runs without an agent use the task base directly. The
+agent type, exact install command, and task-base image identity are included in
+the derived image cache key.
+
 ## Contribute a task
 
 We welcome project-level scientific tasks from the research community. Authors

--- a/README.md
+++ b/README.md
@@ -369,7 +369,8 @@ For `runtime.dockerfile`, the declared Dockerfile builds the reusable task base
 image. When an OS-sandbox agent is selected, ASI-Bench layers only that agent's
 CLI onto the task base; runs without an agent use the task base directly. The
 agent type, exact install command, and task-base image identity are included in
-the derived image cache key.
+the derived image cache key. Formal-task Dockerfiles are fail-closed and must be
+listed exactly for their task in `config/public_task_runtimes.json`.
 
 ## Contribute a task
 

--- a/TEST.md
+++ b/TEST.md
@@ -9,10 +9,12 @@ uv run pytest -q
 ```
 
 The `CI` GitHub Actions workflow runs this suite automatically on every push
-and pull request with Python 3.11 and 3.13. It uses `uv sync --locked` and
-`uv run --frozen`, so CI fails instead of silently rewriting a stale lockfile.
-The stable `CI required` job aggregates the test matrix and package build for
-use as a required branch-protection check.
+and pull request with Python 3.11 and 3.13. It also runs the focused custom-task
+Docker integration suite once on Ubuntu, including pi and Claude Code overlays.
+It uses `uv sync --locked` and `uv run --frozen`, so CI fails instead of silently
+rewriting a stale lockfile. The stable `CI required` job aggregates the test
+matrix, Docker runtime probe, and package build for use as a required
+branch-protection check.
 
 Publishing is tied to a GitHub Release by `.github/workflows/publish.yml`. The
 workflow checks that a tag such as `v0.1.2` matches the package version, reruns
@@ -329,6 +331,8 @@ allowlists and scan the public GitHub tree for GT generators, references, privat
 solver assets, undeclared artifacts, repository identifiers, and secret-like
 content. `config/public_scorers.json` locks all 60 formal scoring contracts, 57
 custom scorers, their exact per-task helper allowlists, and the private source revision.
+`config/public_task_runtimes.json` separately allowlists formal runtime files at
+task granularity and must exactly match `runtime.dockerfile` declarations.
 Formal `task_eval.yaml` files may contain only scoring/output contracts and must
 never contain `generation`. seed31415 references live on Hugging Face, not in
 formal GitHub task directories. The separate Example policy locks five full public

--- a/TEST.md
+++ b/TEST.md
@@ -133,6 +133,17 @@ uv run pytest -q tests/test_os_sandbox.py tests/test_os_sandbox_adapters.py \
   tests/test_native_agent_extractors.py tests/test_integration.py
 ```
 
+Custom task Dockerfile coverage verifies selected-agent overlays, per-agent
+cache identities, single-agent installation, and direct reuse of the task base
+when no agent is selected. A Docker integration probe builds the CMOS op-amp
+base plus the pi overlay, runs it as UID/GID `12345:12345`, and checks writable
+agent homes together with ngspice, the task Python environment, and the pi CLI:
+
+```bash
+uv run pytest -m integration -q \
+  tests/test_os_sandbox_p1p2p3.py::TestTaskDockerfileAgentOverlayIntegration
+```
+
 ## Per-run harness home isolation (claude_code / kimi_code / codex)
 
 CLI harnesses keep session transcripts, history, and auto-memory under their

--- a/ai4sci_bench/runner/task_image.py
+++ b/ai4sci_bench/runner/task_image.py
@@ -163,7 +163,8 @@ class TaskImageBuilder:
                 )
             return custom_image
 
-        # 2. Custom Dockerfile
+        # 2. Custom Dockerfile. Treat the task image as a reusable base and
+        # add only the currently selected agent CLI in a separate overlay.
         custom_dockerfile = task_metadata.get("runtime", {}).get("dockerfile") if isinstance(task_metadata.get("runtime"), dict) else None
         if custom_dockerfile:
             task_dir = task_metadata.get("_task_dir")
@@ -172,24 +173,47 @@ class TaskImageBuilder:
             dockerfile_path = Path(task_dir) / custom_dockerfile
             if not dockerfile_path.exists():
                 raise RuntimeError(f"runtime.dockerfile '{custom_dockerfile}' not found at {dockerfile_path}")
-            tag = self._custom_dockerfile_tag(dockerfile_path)
-            if not self._image_exists(tag):
-                self._build_image_from_file(tag, dockerfile_path, Path(task_dir))
-            return tag
+            task_base_tag = self._custom_dockerfile_tag(dockerfile_path)
+            if not self._image_exists(task_base_tag):
+                self._build_image_from_file(task_base_tag, dockerfile_path, Path(task_dir))
+            return self._ensure_overlay(
+                task_base_tag,
+                task_metadata,
+                agent_type=agent_type,
+                runtime_packages=[],
+            )
 
         # 3. Default: base image + agent CLI + task packages overlay
         base_tag = self.ensure_base_image()
-        runtime_packages = list(task_metadata.get("_runtime_packages", []))
+        return self._ensure_overlay(
+            base_tag,
+            task_metadata,
+            agent_type=agent_type,
+            runtime_packages=list(task_metadata.get("_runtime_packages", [])),
+        )
+
+    def _ensure_overlay(
+        self,
+        base_image: str,
+        task_metadata: dict[str, Any],
+        *,
+        agent_type: str | None,
+        runtime_packages: list[str],
+    ) -> str:
+        """Add the selected agent and packages on top of one task base image."""
         agent_install_cmds = AGENT_INSTALL_COMMANDS.get(agent_type, [])
-
         if not runtime_packages and not agent_install_cmds:
-            return base_tag
+            return base_image
 
-        tag = self._task_agent_image_tag(task_metadata, agent_type)
+        tag = self._task_agent_image_tag(
+            task_metadata,
+            agent_type,
+            base_image=base_image,
+        )
         if self._image_exists(tag):
             return tag
 
-        lines = [f"FROM {base_tag}\n", "USER root\n"]
+        lines = [f"FROM {base_image}\n", "USER root\n"]
         if agent_install_cmds:
             lines.append(f"# Install {agent_type} CLI\n")
             for cmd in agent_install_cmds:
@@ -418,12 +442,19 @@ class TaskImageBuilder:
         cache_key = self.env_manager.compute_cache_key(task_metadata)
         return f"ai4sci-bench-task:{cache_key}"
 
-    def _task_agent_image_tag(self, task_metadata: dict[str, Any], agent_type: str | None) -> str:
+    def _task_agent_image_tag(
+        self,
+        task_metadata: dict[str, Any],
+        agent_type: str | None,
+        *,
+        base_image: str | None = None,
+    ) -> str:
         cache_key = self.env_manager.compute_cache_key(task_metadata)
         agent_suffix = agent_type or "base"
         install_identity = "\n".join(AGENT_INSTALL_COMMANDS.get(agent_type, []))
+        image_identity = base_image or self._base_image_tag()
         payload = (
-            f"{self._base_image_tag()}|{cache_key}|{agent_suffix}|{install_identity}"
+            f"{image_identity}|{cache_key}|{agent_suffix}|{install_identity}"
         ).encode("utf-8")
         digest = hashlib.sha256(payload).hexdigest()[:12]
         return f"ai4sci-bench-task:{digest}"

--- a/config/public_task_runtimes.json
+++ b/config/public_task_runtimes.json
@@ -1,0 +1,8 @@
+{
+  "schema_version": 1,
+  "task_runtime_files": {
+    "electrical_engineering.cmos_opamp_design": [
+      "Dockerfile.os"
+    ]
+  }
+}

--- a/tasks/electrical_engineering/cmos_opamp_design/Dockerfile.os
+++ b/tasks/electrical_engineering/cmos_opamp_design/Dockerfile.os
@@ -39,8 +39,10 @@ RUN /opt/venv/bin/python --version \
 RUN useradd -m -s /bin/bash -u 1000 agent \
     && mkdir -p /opt/ai4sci-bench /home/agent /tmp/agent-auth /workspace \
     && mkdir -p /home/agent/.claude/session-env /home/agent/.claude/sessions \
-    && mkdir -p /home/agent/.codex \
-    && chown -R agent:agent /opt/venv /home/agent /tmp/agent-auth /workspace
+    && mkdir -p /home/agent/.codex /home/agent/.kimi-code \
+    && mkdir -p /home/agent/.local/share/mimocode \
+    && chown -R agent:agent /opt/venv /home/agent /tmp/agent-auth /workspace \
+    && chmod -R 0777 /home/agent /tmp/agent-auth
 
 ENV PATH="/opt/venv/bin:/usr/local/bin:/usr/bin:/bin"
 ENV VIRTUAL_ENV="/opt/venv"

--- a/tasks/electrical_engineering/cmos_opamp_design/Dockerfile.os
+++ b/tasks/electrical_engineering/cmos_opamp_design/Dockerfile.os
@@ -8,8 +8,6 @@ RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
     && apt-get install -y --no-install-recommends nodejs \
     && rm -rf /var/lib/apt/lists/*
 
-RUN npm install -g @anthropic-ai/claude-code @openai/codex
-
 RUN curl -LsSf https://astral.sh/uv/install.sh | sh \
     && mv /root/.local/bin/uv /usr/local/bin/uv \
     && mv /root/.local/bin/uvx /usr/local/bin/uvx
@@ -32,8 +30,6 @@ RUN /opt/venv/bin/python --version \
     && /opt/venv/bin/python -c "import numpy, matplotlib, pandas, scipy, sympy" \
     && node --version \
     && npm --version \
-    && claude --version \
-    && codex --version \
     && ngspice --version
 
 RUN useradd -m -s /bin/bash -u 1000 agent \

--- a/tasks/electrical_engineering/cmos_opamp_design/Dockerfile.os
+++ b/tasks/electrical_engineering/cmos_opamp_design/Dockerfile.os
@@ -1,0 +1,52 @@
+FROM python:3.12-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git curl ca-certificates build-essential ngspice \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
+    && apt-get install -y --no-install-recommends nodejs \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN npm install -g @anthropic-ai/claude-code @openai/codex
+
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh \
+    && mv /root/.local/bin/uv /usr/local/bin/uv \
+    && mv /root/.local/bin/uvx /usr/local/bin/uvx
+
+RUN uv venv /opt/venv
+
+RUN printf '%s\n' \
+    'export PATH="/opt/venv/bin:/usr/local/bin:/usr/bin:/bin"' \
+    'export VIRTUAL_ENV="/opt/venv"' \
+    > /etc/profile.d/ai4sci-venv.sh
+
+RUN uv pip install --python /opt/venv/bin/python \
+    "numpy>=1.24" \
+    "matplotlib>=3.7" \
+    "pandas>=2.0" \
+    "scipy>=1.11" \
+    "sympy>=1.12"
+
+RUN /opt/venv/bin/python --version \
+    && /opt/venv/bin/python -c "import numpy, matplotlib, pandas, scipy, sympy" \
+    && node --version \
+    && npm --version \
+    && claude --version \
+    && codex --version \
+    && ngspice --version
+
+RUN useradd -m -s /bin/bash -u 1000 agent \
+    && mkdir -p /opt/ai4sci-bench /home/agent /tmp/agent-auth /workspace \
+    && mkdir -p /home/agent/.claude/session-env /home/agent/.claude/sessions \
+    && mkdir -p /home/agent/.codex \
+    && chown -R agent:agent /opt/venv /home/agent /tmp/agent-auth /workspace
+
+ENV PATH="/opt/venv/bin:/usr/local/bin:/usr/bin:/bin"
+ENV VIRTUAL_ENV="/opt/venv"
+ENV AI4SCI_SANDBOX="1"
+ENV HOME="/home/agent"
+ENV LANG="C.UTF-8"
+
+USER agent
+WORKDIR /workspace

--- a/tests/test_ci_workflow.py
+++ b/tests/test_ci_workflow.py
@@ -21,8 +21,12 @@ def test_ci_runs_locked_tests_and_build_checks_on_push_and_pull_requests():
     assert workflow["permissions"] == {"contents": "read"}
 
     jobs = workflow["jobs"]
-    assert {"tests", "build", "required"} <= jobs.keys()
-    assert jobs["required"]["needs"] == ["tests", "build"]
+    assert {"tests", "build", "docker-integration", "required"} <= jobs.keys()
+    assert jobs["required"]["needs"] == [
+        "tests",
+        "build",
+        "docker-integration",
+    ]
 
     test_commands = "\n".join(
         step.get("run", "") for step in jobs["tests"]["steps"]
@@ -37,6 +41,13 @@ def test_ci_runs_locked_tests_and_build_checks_on_push_and_pull_requests():
     assert "twine check --strict" in build_commands
     assert "dist/*.whl" in build_commands
     assert "asibench --help" in build_commands
+
+    docker_commands = "\n".join(
+        step.get("run", "") for step in jobs["docker-integration"]["steps"]
+    )
+    assert "docker info" in docker_commands
+    assert "-m integration" in docker_commands
+    assert "TestTaskDockerfileAgentOverlayIntegration" in docker_commands
 
 
 def test_agent_instruction_files_are_regular_and_synchronized():

--- a/tests/test_os_sandbox.py
+++ b/tests/test_os_sandbox.py
@@ -802,6 +802,13 @@ class TestTaskImageBuilder:
                 tag2 = builder._task_agent_image_tag(metadata, "pi")
         assert tag1 != tag2
 
+    def test_agent_image_tag_depends_on_agent_type(self, builder: TaskImageBuilder):
+        metadata = {"_runtime_packages": []}
+        with patch.object(builder.env_manager, "compute_cache_key", return_value="task-key"):
+            pi_tag = builder._task_agent_image_tag(metadata, "pi", base_image="custom:base")
+            codex_tag = builder._task_agent_image_tag(metadata, "codex", base_image="custom:base")
+        assert pi_tag != codex_tag
+
     def test_ensure_base_image_returns_cached(self, builder: TaskImageBuilder):
         with patch.object(builder, "ensure_docker_available"), \
              patch.object(builder, "_image_exists", return_value=True):
@@ -840,6 +847,69 @@ class TestTaskImageBuilder:
         with patch.object(builder, "ensure_base_image", return_value="ai4sci-bench-base:abc"):
             tag = builder.ensure_image({})
             assert tag == "ai4sci-bench-base:abc"
+
+    def test_custom_dockerfile_with_pi_builds_agent_overlay(
+        self, builder: TaskImageBuilder, tmp_path: Path
+    ):
+        task_dir = tmp_path / "task"
+        task_dir.mkdir()
+        dockerfile = task_dir / "Dockerfile.os"
+        dockerfile.write_text("FROM python:3.12-slim\n", encoding="utf-8")
+        metadata = {
+            "runtime": {"dockerfile": "Dockerfile.os"},
+            "_task_dir": str(task_dir),
+            "_runtime_packages": [],
+        }
+
+        with patch.object(builder, "_image_exists", return_value=False), \
+             patch.object(builder, "_build_image_from_file") as mock_build_base, \
+             patch.object(builder, "_build_image") as mock_build_overlay, \
+             patch.object(builder.env_manager, "compute_cache_key", return_value="task-key"):
+            image = builder.ensure_image(metadata, agent_type="pi")
+
+        custom_base = builder._custom_dockerfile_tag(dockerfile)
+        assert image.startswith("ai4sci-bench-task:")
+        mock_build_base.assert_called_once_with(custom_base, dockerfile, task_dir)
+        overlay = mock_build_overlay.call_args.args[1]
+        assert f"FROM {custom_base}" in overlay
+        assert "npm install -g @earendil-works/pi-coding-agent@0.84.3" in overlay
+
+    def test_agent_overlay_installs_only_selected_agent(
+        self, builder: TaskImageBuilder
+    ):
+        metadata = {"_runtime_packages": []}
+        with patch.object(builder, "ensure_base_image", return_value="base:test"), \
+             patch.object(builder, "_image_exists", return_value=False), \
+             patch.object(builder, "_build_image") as mock_build, \
+             patch.object(builder.env_manager, "compute_cache_key", return_value="task-key"):
+            builder.ensure_image(metadata, agent_type="pi")
+
+        overlay = mock_build.call_args.args[1]
+        assert "@earendil-works/pi-coding-agent@0.84.3" in overlay
+        assert "@anthropic-ai/claude-code" not in overlay
+        assert "@openai/codex" not in overlay
+        assert "opencode-ai" not in overlay
+
+    def test_custom_dockerfile_without_agent_returns_task_base(
+        self, builder: TaskImageBuilder, tmp_path: Path
+    ):
+        task_dir = tmp_path / "task"
+        task_dir.mkdir()
+        dockerfile = task_dir / "Dockerfile.os"
+        dockerfile.write_text("FROM python:3.12-slim\n", encoding="utf-8")
+        metadata = {
+            "runtime": {"dockerfile": "Dockerfile.os"},
+            "_task_dir": str(task_dir),
+        }
+
+        with patch.object(builder, "_image_exists", return_value=False), \
+             patch.object(builder, "_build_image_from_file") as mock_build_base, \
+             patch.object(builder, "_build_image") as mock_build_overlay:
+            image = builder.ensure_image(metadata)
+
+        assert image == builder._custom_dockerfile_tag(dockerfile)
+        mock_build_base.assert_called_once()
+        mock_build_overlay.assert_not_called()
 
     def test_ensure_image_builds_task_image_with_packages(self, builder: TaskImageBuilder):
         with patch.object(builder, "ensure_base_image", return_value="ai4sci-bench-base:abc"), \

--- a/tests/test_os_sandbox.py
+++ b/tests/test_os_sandbox.py
@@ -874,6 +874,38 @@ class TestTaskImageBuilder:
         assert f"FROM {custom_base}" in overlay
         assert "npm install -g @earendil-works/pi-coding-agent@0.84.3" in overlay
 
+    def test_custom_dockerfile_content_changes_agent_overlay_tag(
+        self, builder: TaskImageBuilder, tmp_path: Path
+    ):
+        task_dir = tmp_path / "task"
+        task_dir.mkdir()
+        dockerfile = task_dir / "Dockerfile.os"
+        metadata = {
+            "runtime": {"dockerfile": dockerfile.name},
+            "_task_dir": str(task_dir),
+            "_runtime_packages": [],
+        }
+
+        with patch.object(builder, "_image_exists", return_value=False), \
+             patch.object(builder, "_build_image_from_file"), \
+             patch.object(builder, "_build_image") as mock_build_overlay, \
+             patch.object(builder.env_manager, "compute_cache_key", return_value="task-key"):
+            dockerfile.write_text("FROM python:3.12-slim\n", encoding="utf-8")
+            first_image = builder.ensure_image(metadata, agent_type="pi")
+            first_overlay = mock_build_overlay.call_args.args[1]
+
+            dockerfile.write_text(
+                "FROM python:3.12-slim\nRUN echo changed\n",
+                encoding="utf-8",
+            )
+            second_image = builder.ensure_image(metadata, agent_type="pi")
+            second_overlay = mock_build_overlay.call_args.args[1]
+
+        assert first_image != second_image
+        assert first_overlay != second_overlay
+        assert "FROM ai4sci-bench-custom:" in first_overlay
+        assert "FROM ai4sci-bench-custom:" in second_overlay
+
     def test_agent_overlay_installs_only_selected_agent(
         self, builder: TaskImageBuilder
     ):

--- a/tests/test_os_sandbox_p1p2p3.py
+++ b/tests/test_os_sandbox_p1p2p3.py
@@ -874,8 +874,8 @@ class TestDockerIntegration:
 class TestTaskDockerfileAgentOverlayIntegration:
     """Validate the formal CMOS task image and its selected-agent overlay."""
 
-    def test_cmos_task_pi_overlay_runtime_contract(self):
-        repo_root = Path(__file__).resolve().parents[1]
+    @staticmethod
+    def _metadata(repo_root: Path) -> tuple[Path, Path, dict]:
         task_dir = repo_root / "tasks" / "electrical_engineering" / "cmos_opamp_design"
         dockerfile = task_dir / "Dockerfile.os"
         metadata = {
@@ -883,6 +883,11 @@ class TestTaskDockerfileAgentOverlayIntegration:
             "_task_dir": str(task_dir),
             "_runtime_packages": [],
         }
+        return task_dir, dockerfile, metadata
+
+    def test_cmos_task_pi_overlay_runtime_contract(self):
+        repo_root = Path(__file__).resolve().parents[1]
+        _, dockerfile, metadata = self._metadata(repo_root)
         builder = TaskImageBuilder(repo_root)
 
         task_base = builder.ensure_image(metadata)
@@ -913,6 +918,38 @@ class TestTaskDockerfileAgentOverlayIntegration:
                 "pi --version; "
                 "! command -v claude; "
                 "! command -v codex",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=1800,
+        )
+        assert probe.returncode == 0, probe.stderr or probe.stdout
+
+    def test_cmos_task_claude_code_overlay_cli_smoke(self):
+        repo_root = Path(__file__).resolve().parents[1]
+        _, dockerfile, metadata = self._metadata(repo_root)
+        builder = TaskImageBuilder(repo_root)
+
+        task_base = builder.ensure_image(metadata)
+        claude_image = builder.ensure_image(metadata, agent_type="claude_code")
+
+        assert task_base == builder._custom_dockerfile_tag(dockerfile)
+        assert claude_image != task_base
+        probe = subprocess.run(
+            [
+                "docker",
+                "run",
+                "--rm",
+                "--user",
+                "12345:12345",
+                claude_image,
+                "/bin/bash",
+                "-lc",
+                "set -eu; "
+                "test -x \"$(command -v claude)\"; "
+                "claude --version; "
+                "! command -v codex; "
+                "! command -v pi",
             ],
             capture_output=True,
             text=True,

--- a/tests/test_os_sandbox_p1p2p3.py
+++ b/tests/test_os_sandbox_p1p2p3.py
@@ -869,6 +869,58 @@ class TestDockerIntegration:
         assert builder.check_daemon_health() is True
 
 
+@pytest.mark.integration
+@needs_docker
+class TestTaskDockerfileAgentOverlayIntegration:
+    """Validate the formal CMOS task image and its selected-agent overlay."""
+
+    def test_cmos_task_pi_overlay_runtime_contract(self):
+        repo_root = Path(__file__).resolve().parents[1]
+        task_dir = repo_root / "tasks" / "electrical_engineering" / "cmos_opamp_design"
+        dockerfile = task_dir / "Dockerfile.os"
+        metadata = {
+            "runtime": {"dockerfile": dockerfile.name},
+            "_task_dir": str(task_dir),
+            "_runtime_packages": [],
+        }
+        builder = TaskImageBuilder(repo_root)
+
+        task_base = builder.ensure_image(metadata)
+        pi_image = builder.ensure_image(metadata, agent_type="pi")
+
+        assert task_base == builder._custom_dockerfile_tag(dockerfile)
+        assert pi_image != task_base
+        probe = subprocess.run(
+            [
+                "docker",
+                "run",
+                "--rm",
+                "--user",
+                "12345:12345",
+                pi_image,
+                "/bin/bash",
+                "-lc",
+                "set -eu; "
+                "touch /home/agent/.claude/session-env/probe "
+                "/home/agent/.claude/sessions/probe "
+                "/home/agent/.codex/probe "
+                "/home/agent/.kimi-code/probe "
+                "/home/agent/.local/share/mimocode/probe "
+                "/tmp/agent-auth/probe; "
+                "test \"$(command -v python)\" = /opt/venv/bin/python; "
+                "python -c 'import numpy, matplotlib, pandas, scipy, sympy'; "
+                "ngspice --version; "
+                "pi --version; "
+                "! command -v claude; "
+                "! command -v codex",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=1800,
+        )
+        assert probe.returncode == 0, probe.stderr or probe.stdout
+
+
 # ============================================================
 # P3: End-to-end benchmark test patterns
 # ============================================================

--- a/tests/test_public_task_policy.py
+++ b/tests/test_public_task_policy.py
@@ -15,6 +15,7 @@ ROOT = Path(__file__).resolve().parents[1]
 TASKS = ROOT / "tasks"
 POLICY_PATH = ROOT / "config" / "public_examples.json"
 SCORER_POLICY_PATH = ROOT / "config" / "public_scorers.json"
+RUNTIME_POLICY_PATH = ROOT / "config" / "public_task_runtimes.json"
 PROTECTED_FILENAMES = frozenset({
     "task.yaml",
             "task_eval.yaml",
@@ -157,6 +158,10 @@ def _load_scorer_policy() -> dict:
     return json.loads(SCORER_POLICY_PATH.read_text(encoding="utf-8"))
 
 
+def _load_runtime_policy() -> dict:
+    return json.loads(RUNTIME_POLICY_PATH.read_text(encoding="utf-8"))
+
+
 def _task_dir(task_id: str) -> Path:
     if task_id == "_template":
         return TASKS / task_id
@@ -205,6 +210,20 @@ def _scorer_public_paths() -> set[str]:
         for filename in helpers.get(task_id, []):
             paths.add((task_root / filename).as_posix())
     return paths
+
+
+def _runtime_public_paths() -> set[str]:
+    policy = _load_runtime_policy()
+    paths: set[str] = set()
+    for task_id, filenames in policy["task_runtime_files"].items():
+        task_root = _task_dir(task_id).relative_to(TASKS)
+        for filename in filenames:
+            paths.add((task_root / filename).as_posix())
+    return paths
+
+
+def _formal_public_paths() -> set[str]:
+    return _scorer_public_paths() | _runtime_public_paths()
 
 
 def _tracked_paths() -> list[Path]:
@@ -271,10 +290,12 @@ def _declared_public_files(task_dir: Path, entry: dict | None) -> set[str]:
     elif document.get("status") == "final":
         task_id = document["id"]
         scorer_policy = _load_scorer_policy()
+        runtime_policy = _load_runtime_policy()
         allowed.add("task_eval.yaml")
         if task_id in scorer_policy["tasks_with_custom_scorers"]:
             allowed.add("custom_scorer.py")
         allowed.update(scorer_policy["task_helper_files"].get(task_id, []))
+        allowed.update(runtime_policy["task_runtime_files"].get(task_id, []))
     return allowed
 
 
@@ -341,6 +362,36 @@ def test_formal_scorer_allowlist_is_exact_and_references_existing_files():
     for relative in _scorer_public_paths():
         target = TASKS / relative
         assert target.is_file() and not target.is_symlink(), relative
+
+
+def test_formal_task_runtime_allowlist_is_exact_and_matches_metadata():
+    policy = _load_runtime_policy()
+    assert policy["schema_version"] == 1
+    assert set(policy) == {"schema_version", "task_runtime_files"}
+
+    scorer_policy = _load_scorer_policy()
+    runtime_files = policy["task_runtime_files"]
+    assert set(runtime_files) <= set(scorer_policy["formal_tasks"])
+
+    declared: dict[str, list[str]] = {}
+    for task_id in scorer_policy["formal_tasks"]:
+        metadata = yaml.safe_load(
+            (_task_dir(task_id) / "task_meta.yaml").read_text(encoding="utf-8")
+        )
+        runtime = metadata.get("runtime", {})
+        dockerfile = runtime.get("dockerfile") if isinstance(runtime, dict) else None
+        if dockerfile is not None:
+            declared[task_id] = [dockerfile]
+
+    assert runtime_files == declared
+    for task_id, filenames in runtime_files.items():
+        assert filenames and len(filenames) == len(set(filenames)), task_id
+        for filename in filenames:
+            relative = PurePosixPath(filename)
+            assert filename == relative.as_posix(), (task_id, filename)
+            assert relative.parent == PurePosixPath("."), (task_id, filename)
+            target = _task_dir(task_id) / filename
+            assert target.is_file() and not target.is_symlink(), (task_id, filename)
 
 
 def test_formal_task_eval_files_publish_scoring_but_never_generation():
@@ -540,22 +591,22 @@ def test_public_catalog_has_exact_final_and_sample_statuses():
     assert stale_abandoned_reasons == []
 
 
-def test_non_example_benchmark_tasks_track_only_metadata_and_public_scorers():
+def test_non_example_benchmark_tasks_track_only_declared_public_files():
     example_dirs = {_task_dir(task_id) for task_id in EXPECTED_EXAMPLES}
-    scorer_paths = _scorer_public_paths()
+    public_paths = _formal_public_paths()
     violations = []
     for path in _tracked_paths():
         if TASKS not in path.parents or path.parent in example_dirs:
             continue
         relative = path.relative_to(TASKS).as_posix()
-        if path.name != "task_meta.yaml" and relative not in scorer_paths:
+        if path.name != "task_meta.yaml" and relative not in public_paths:
             violations.append(path.relative_to(ROOT).as_posix())
     assert violations == []
 
 
 def test_private_like_files_only_exist_at_allowlisted_example_paths():
     policy = _load_policy()
-    allowed_paths = _allowlisted_paths(policy) | _scorer_public_paths()
+    allowed_paths = _allowlisted_paths(policy) | _formal_public_paths()
 
     violations = []
     for path in TASKS.rglob("*"):


### PR DESCRIPTION
## Summary

- add the CMOS op-amp task image and upgrade its Node.js from 20 to 22
- preserve `/opt/venv/bin` in login shells

## Validation

- Docker image built successfully with `--no-cache`
- verified Python scientific-package imports
- verified Node.js, Claude Code, Codex CLI, and ngspice
- verified `/bin/bash -lc` resolves Python to `/opt/venv/bin/python`

## Scope

This PR contains only the CMOS op-amp task Dockerfile.
Local benchmark instances, result files, temporary Docker contexts,
`.DS_Store`, and the temporary legacy `task.yaml` are excluded.